### PR TITLE
Fix setInterval and add pull to refresh for stop estimates

### DIFF
--- a/app/components/MapView.tsx
+++ b/app/components/MapView.tsx
@@ -22,10 +22,12 @@ const Index: React.FC = () => {
     const presentSheet = useAppStore((state) => state.presentSheet);
     const drawnRoutes = useAppStore((state) => state.drawnRoutes);
 
+    const setBusRefreshInterval = useAppStore((state) => state.setBusRefreshInterval);
+    const clearBusRefreshInterval = useAppStore((state) => state.clearBusRefreshInterval);
+
     const [isViewCenteredOnUser, setIsViewCenteredOnUser] = useState(false);
 
     const [buses, setBuses] = useState<IVehicle[]>([]);
-    const updateBusesInterval = useRef<NodeJS.Timeout | null>(null);
 
     const defaultMapRegion: Region = {
         latitude: 30.6060,
@@ -80,17 +82,22 @@ const Index: React.FC = () => {
 
         // Handle updating buses based on the number of drawn routes
         if (drawnRoutes.length === 1 && drawnRoutes[0]?.shortName) {
-
             // Update the buses initially
             updateBuses();
 
             // Set up interval to update buses every 5 seconds
-            updateBusesInterval.current = setInterval(async () => {
+            setBusRefreshInterval(setInterval(async () => {
                 await updateBuses();
-            }, 5000);
+            }, 5000));
         } else {
             // Clear the interval and reset the buses if there are no drawn routes or more than one
-            clearInterval(updateBusesInterval.current!);
+            clearBusRefreshInterval();
+            setBuses([]);
+        }
+
+        // Clear the interval and reset the buses if the component unmounts
+        return () => {
+            clearBusRefreshInterval();
             setBuses([]);
         }
     }, [drawnRoutes]);

--- a/app/components/MapView.tsx
+++ b/app/components/MapView.tsx
@@ -76,7 +76,6 @@ const Index: React.FC = () => {
     // If the user toggles between on-campus and off-campus routes, adjust the zoom level of the map
     // Ignore if the mapRenderCount is less than 2 since it takes two renders to show the initial region
     useEffect(() => {
-        console.log(drawnRoutes[0]?.shortName)
         centerViewOnRoutes();
 
         // Handle updating buses based on the number of drawn routes

--- a/app/components/MapView.tsx
+++ b/app/components/MapView.tsx
@@ -5,7 +5,7 @@ import * as Location from 'expo-location';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { getVehicles } from "aggie-spirit-api";
 
-import { GetVehiclesResponseSchema, IGetVehiclesResponse, IVehicle } from "../../utils/interfaces";
+import { GetVehiclesResponseSchema, IGetVehiclesResponse, IMapRoute, IVehicle } from "../../utils/interfaces";
 import StopCallout from "./callouts/StopCallout";
 import BusCallout from "./callouts/BusCallout";
 import BusMapIcon from "./callouts/BusMapIcon";
@@ -17,6 +17,9 @@ const Index: React.FC = () => {
     const authToken = useAppStore((state) => state.authToken);
 
     const selectedRoute = useAppStore((state) => state.selectedRoute);
+    const setSelectedRoute = useAppStore((state) => state.setSelectedRoute);
+    const setDrawnRoutes = useAppStore((state) => state.setDrawnRoutes);
+    const presentSheet = useAppStore((state) => state.presentSheet);
     const drawnRoutes = useAppStore((state) => state.drawnRoutes);
 
     const [isViewCenteredOnUser, setIsViewCenteredOnUser] = useState(false);
@@ -61,10 +64,19 @@ const Index: React.FC = () => {
 
         setBuses(extracted)
     }
+    
+    function selectRoute(route: IMapRoute) {
+        if (selectedRoute?.key === route.key) return;
+
+        setSelectedRoute(route);
+        setDrawnRoutes([route]);
+        presentSheet("routeDetails");
+    }
 
     // If the user toggles between on-campus and off-campus routes, adjust the zoom level of the map
     // Ignore if the mapRenderCount is less than 2 since it takes two renders to show the initial region
     useEffect(() => {
+        console.log(drawnRoutes[0]?.shortName)
         centerViewOnRoutes();
 
         // Handle updating buses based on the number of drawn routes
@@ -197,7 +209,7 @@ const Index: React.FC = () => {
                     })
 
                     return (
-                        <Polyline key={drawnRoute.key} coordinates={coords} strokeColor={lineColor} strokeWidth={6} />
+                        <Polyline key={drawnRoute.key} coordinates={coords} strokeColor={lineColor} strokeWidth={6} onPress={() => selectRoute(drawnRoute)}/>
                     )
                 })}
 

--- a/app/components/MapView.tsx
+++ b/app/components/MapView.tsx
@@ -3,8 +3,9 @@ import { Alert, Dimensions, TouchableOpacity, View } from "react-native";
 import MapView, { LatLng, Polyline, Marker, Region } from 'react-native-maps';
 import * as Location from 'expo-location';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { Vehicle, VehicleResponse, getVehicles } from "aggie-spirit-api";
+import { getVehicles } from "aggie-spirit-api";
 
+import { GetVehiclesResponseSchema, IGetVehiclesResponse, IVehicle } from "../../utils/interfaces";
 import StopCallout from "./callouts/StopCallout";
 import BusCallout from "./callouts/BusCallout";
 import BusMapIcon from "./callouts/BusMapIcon";
@@ -20,7 +21,7 @@ const Index: React.FC = () => {
 
     const [isViewCenteredOnUser, setIsViewCenteredOnUser] = useState(false);
 
-    const [buses, setBuses] = useState<Vehicle[]>([]);
+    const [buses, setBuses] = useState<IVehicle[]>([]);
     const updateBusesInterval = useRef<NodeJS.Timeout | null>(null);
 
     const defaultMapRegion: Region = {
@@ -33,9 +34,11 @@ const Index: React.FC = () => {
     const updateBuses = async () => {
         if (!selectedRoute || !authToken) return
 
-        let busesResponse: VehicleResponse[]
+        let busesResponse: IGetVehiclesResponse
         try {
-            busesResponse = await getVehicles([selectedRoute.key], authToken)
+            busesResponse = await getVehicles([selectedRoute.key], authToken) as IGetVehiclesResponse;
+
+            GetVehiclesResponseSchema.parse(busesResponse);
         } catch (error) {
             console.error(error);
             
@@ -49,7 +52,7 @@ const Index: React.FC = () => {
             return
         }
 
-        let extracted: Vehicle[] = []
+        let extracted: IVehicle[] = []
         for (let direction of busesResponse[0]?.vehiclesByDirections) {
             for (let bus of direction.vehicles) {
                 extracted.push(bus)

--- a/app/components/MapView.tsx
+++ b/app/components/MapView.tsx
@@ -210,6 +210,7 @@ const Index: React.FC = () => {
                                         latitude: patternPoint.latitude,
                                         longitude: patternPoint.longitude
                                     }}
+                                    tracksViewChanges={false}
                                 >
                                     <View
                                         style={{

--- a/app/components/callouts/BusCallout.tsx
+++ b/app/components/callouts/BusCallout.tsx
@@ -1,15 +1,13 @@
 import React from 'react'
 import { View, Text } from 'react-native'
 import { Callout } from 'react-native-maps'
-import { Amenity, Vehicle } from 'aggie-spirit-api'
-
 import Ionicons from '@expo/vector-icons/Ionicons';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 
+import { IAmenity, IVehicle } from '../../../utils/interfaces';
 import BusIcon from '../ui/BusIcon'
-
 interface Props {
-  bus: Vehicle
+  bus: IVehicle
   tintColor: string
   routeName: string
 }
@@ -25,7 +23,7 @@ const BusCallout: React.FC<Props> = ({ bus, tintColor, routeName }) => {
           <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', marginBottom: 4 }}>
             <BusIcon name={routeName} color={tintColor} isCallout={true} style={{ marginRight: 8 }}/>
             <View style={{ flex: 1 }}/>
-            { bus.amenities.map((amenity: Amenity, index) => (
+            { bus.amenities.map((amenity: IAmenity, index) => (
                 amenity.name == "Air Conditioning" ? (<Ionicons key={index} name="snow" size={18} color="gray" style={{ paddingLeft: 4 }} />) : (<MaterialCommunityIcons key={index} name="wheelchair-accessibility" size={18} color="gray" style={{ paddingLeft: 4 }} />)
               ))
             }

--- a/app/components/callouts/BusMapIcon.tsx
+++ b/app/components/callouts/BusMapIcon.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { View } from 'react-native'
-
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 interface Props {

--- a/app/components/callouts/StopCallout.tsx
+++ b/app/components/callouts/StopCallout.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react'
 import { View, Text } from 'react-native'
 import { Callout } from 'react-native-maps'
-import { MapStop, NextDepartureTimesResponse } from 'aggie-spirit-api'
 
 import BusIcon from '../ui/BusIcon'
 import useAppStore from '../../stores/useAppStore'
+import { IGetNextDepartTimesResponse, IStop } from '../../../utils/interfaces'
 
 interface Props {
-    stop: MapStop
+    stop: IStop
     tintColor: string
     routeName: string
 }
@@ -15,7 +15,7 @@ interface Props {
 const StopCallout: React.FC<Props> = ({ stop, tintColor, routeName }) => {
     const [contentSize, setContentSizing] = useState([0, 15]);
     
-    const [estimate, setEstimate] = useState<NextDepartureTimesResponse | undefined>(undefined);
+    const [estimate, setEstimate] = useState<IGetNextDepartTimesResponse | undefined>(undefined);
     const stopEstimates = useAppStore((state) => state.stopEstimates);
 
     useEffect(() => {

--- a/app/components/sheets/AlertList.tsx
+++ b/app/components/sheets/AlertList.tsx
@@ -41,7 +41,7 @@ const AlertList: React.FC<SheetProps> = ({ sheetRef }) => {
                 data={alerts}
                 keyExtractor={alert => alert.name}
                 style={{ height: "100%", marginLeft: 16 }}
-                contentContainerStyle={{ paddingBottom: 30, paddingRight: 16 }}
+                contentContainerStyle={{ paddingBottom: 35, paddingRight: 16 }}
                 renderItem={({ item: alert }) => {
                     return (
                         <View style={{ 

--- a/app/components/sheets/RouteDetails.tsx
+++ b/app/components/sheets/RouteDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, TouchableOpacity, NativeSyntheticEvent, ActivityIndicator, FlatList } from "react-native";
+import { View, Text, TouchableOpacity, NativeSyntheticEvent } from "react-native";
 import { BottomSheetModal, BottomSheetView, BottomSheetFlatList } from "@gorhom/bottom-sheet";
 import SegmentedControl, { NativeSegmentedControlIOSChangeEvent } from "@react-native-segmented-control/segmented-control";
 import { Ionicons } from '@expo/vector-icons';
@@ -8,7 +8,6 @@ import { MapPatternPath, MapRoute, MapStop, RouteDirectionTime, getNextDeparture
 import useAppStore from "../../stores/useAppStore";
 import RouteEstimates from "../ui/RouteEstimates";
 import BusIcon from "../ui/BusIcon";
-import TimeBubble from "../ui/TimeBubble";
 import FavoritePill from "../ui/FavoritePill";
 
 interface SheetProps {
@@ -21,6 +20,10 @@ const RouteDetails: React.FC<SheetProps> = ({ sheetRef }) => {
 
     const currentSelectedRoute = useAppStore((state) => state.selectedRoute);
     const clearSelectedRoute = useAppStore((state) => state.clearSelectedRoute);
+
+    const favoriteRoutes = useAppStore(state => state.favoriteRoutes);
+
+    const setDrawnRoutes = useAppStore(state => state.setDrawnRoutes);
 
     const stopEstimates = useAppStore((state) => state.stopEstimates);
     const clearStopEstimates = useAppStore((state) => state.clearStopEstimates);
@@ -35,6 +38,9 @@ const RouteDetails: React.FC<SheetProps> = ({ sheetRef }) => {
         sheetRef.current?.dismiss();
         clearSelectedRoute();
         clearStopEstimates();
+
+        // Fixes Android bug when switching from Favorites -> RouteDetails to RouteList, the FlatList does not render the favoriteRoutes and instead renders all routes
+        setDrawnRoutes(favoriteRoutes);
 
         // reset direction selector
         setSelectedDirection(0);

--- a/app/components/sheets/RouteDetails.tsx
+++ b/app/components/sheets/RouteDetails.tsx
@@ -22,10 +22,6 @@ const RouteDetails: React.FC<SheetProps> = ({ sheetRef }) => {
     const currentSelectedRoute = useAppStore((state) => state.selectedRoute);
     const clearSelectedRoute = useAppStore((state) => state.clearSelectedRoute);
 
-    const favoriteRoutes = useAppStore(state => state.favoriteRoutes);
-
-    const setDrawnRoutes = useAppStore(state => state.setDrawnRoutes);
-
     const stopEstimates = useAppStore((state) => state.stopEstimates);
     const clearStopEstimates = useAppStore((state) => state.clearStopEstimates);
     const updateStopEstimate = useAppStore((state) => state.updateStopEstimate);
@@ -39,9 +35,6 @@ const RouteDetails: React.FC<SheetProps> = ({ sheetRef }) => {
         sheetRef.current?.dismiss();
         clearSelectedRoute();
         clearStopEstimates();
-
-        // Fixes Android bug when switching from Favorites -> RouteDetails to RouteList, the FlatList does not render the favoriteRoutes and instead renders all routes
-        setDrawnRoutes(favoriteRoutes);
 
         // reset direction selector
         setSelectedDirectionIndex(0);

--- a/app/components/sheets/RouteDetails.tsx
+++ b/app/components/sheets/RouteDetails.tsx
@@ -65,10 +65,12 @@ const RouteDetails: React.FC<SheetProps> = ({ sheetRef }) => {
     useEffect(() => {
         if (!currentSelectedRoute) return;
         setSelectedRoute(currentSelectedRoute);
+
         loadStopEstimates();
     }, [currentSelectedRoute])
 
     async function loadStopEstimates() {
+        clearStopEstimates();
 
         if (!currentSelectedRoute || !authToken) return;
         let allStops: IStop[] = [];
@@ -142,6 +144,8 @@ const RouteDetails: React.FC<SheetProps> = ({ sheetRef }) => {
                     data={processedStops}
                     style={{ height: "100%", marginLeft: 16 }}
                     contentContainerStyle={{ paddingBottom: 35 }}
+                    onRefresh={() => loadStopEstimates()}
+                    refreshing={false}
                     ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: "#eaeaea", marginVertical: 4 }} />}
                     renderItem={({ item: stop, index }) => {
                         const departureTimes = stopEstimates.find((stopEstimate) => stopEstimate.stopCode === stop.stopCode);

--- a/app/components/sheets/RouteDetails.tsx
+++ b/app/components/sheets/RouteDetails.tsx
@@ -9,7 +9,6 @@ import useAppStore from "../../stores/useAppStore";
 import StopCell from "../ui/StopCell";
 import BusIcon from "../ui/BusIcon";
 import FavoritePill from "../ui/FavoritePill";
-import { set } from "zod";
 
 interface SheetProps {
     sheetRef: React.RefObject<BottomSheetModal>

--- a/app/components/sheets/RoutesList.tsx
+++ b/app/components/sheets/RoutesList.tsx
@@ -69,8 +69,8 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
     }, [alerts]);
 
     // Update the favorites when the view is focused
-    function onAnimate(from: number, to: number) {
-        if (from === -1 && to === 1) {
+    function onAnimate(from: number, _: number) {
+        if (from === -1) {
             loadFavorites();
 
             // match the selectedRouteCategory on the map
@@ -79,8 +79,6 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
             } else {
                 setDrawnRoutes(favoriteRoutes);
             }
-
-            //TODO: write global fucntion to recenter map on drawn routes, right now it just goes back to default
         }
     }
 

--- a/app/components/sheets/RoutesList.tsx
+++ b/app/components/sheets/RoutesList.tsx
@@ -124,11 +124,11 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
                 )}
 
                 {/* Loading indicatior */}
-                { routes.length == 0 && <ActivityIndicator style={{ marginTop: 8 }} /> }
+                { routes.length == 0 && <ActivityIndicator style={{ marginTop: 12 }} /> }
             </BottomSheetView>
 
             <BottomSheetFlatList
-                contentContainerStyle={{ paddingBottom: 30 }}
+                contentContainerStyle={{ paddingBottom: 35 }}
                 data={drawnRoutes}
                 keyExtractor={(route: MapRoute) => route.key}
                 style={{ marginLeft: 16 }}

--- a/app/components/sheets/RoutesList.tsx
+++ b/app/components/sheets/RoutesList.tsx
@@ -20,16 +20,18 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
     const routes = useAppStore((state) => state.routes);
     const setSelectedRoute = useAppStore((state) => state.setSelectedRoute);
     
+    const favoriteRoutes = useAppStore(state => state.favoriteRoutes);
+    const setFavoriteRoutes = useAppStore(state => state.setFavoriteRoutes);
+
     const drawnRoutes = useAppStore((state) => state.drawnRoutes);
     const setDrawnRoutes = useAppStore((state) => state.setDrawnRoutes);
     
     const presentSheet = useAppStore((state) => state.presentSheet);
-
+    
     const [selectedRouteCategory, setSelectedRouteCategory] = useState<"favorites" | "all">("all");
-    const [favorites, setFavorites] = useState<string[]>([]);
     const [alertIcon, setAlertIcon] = useState<"bell-outline" | "bell-badge">("bell-outline");
 
-    const handleRouteSelected = (selectedRoute: MapRoute) => {
+    const handleRouteSelected = (selectedRoute: MapRoute) => {        
         setSelectedRoute(selectedRoute);
         setDrawnRoutes([selectedRoute]);
         presentSheet("routeDetails");
@@ -40,7 +42,8 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
             if (!favorites) return;
 
             const favoritesArray = JSON.parse(favorites);
-            setFavorites(favoritesArray);
+
+            setFavoriteRoutes(routes.filter(route => favoritesArray.includes(route.key)));
         })
     }
 
@@ -52,10 +55,9 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
         if (selectedRouteCategory === "all") {
             setDrawnRoutes(routes);
         } else {
-            const filtered = routes.filter(route => favorites.includes(route.key));
-            setDrawnRoutes(filtered);
+            setDrawnRoutes(favoriteRoutes);
         }
-    }, [selectedRouteCategory, routes, favorites]);
+    }, [selectedRouteCategory, routes, favoriteRoutes]);
 
     // Update the alert icon when the alerts change
     useEffect(() => {
@@ -75,8 +77,7 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
             if (selectedRouteCategory === "all") {
                 setDrawnRoutes(routes);
             } else {
-                const filtered = routes.filter(route => favorites.includes(route.key));
-                setDrawnRoutes(filtered);
+                setDrawnRoutes(favoriteRoutes);
             }
 
             //TODO: write global fucntion to recenter map on drawn routes, right now it just goes back to default
@@ -139,7 +140,7 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
                             <View>                                
                                 <View style={{flexDirection: 'row', alignItems: 'center'}}>
                                     <Text style={{ fontWeight: 'bold', fontSize: 20, lineHeight: 28 }}>{route.name}</Text>
-                                    {favorites.includes(route.key) && 
+                                    {favoriteRoutes.includes(route) && 
                                         <FontAwesome name="star" size={16} color="#ffcc01" style={{marginLeft: 4}} />
                                     }
                                 </View>

--- a/app/components/sheets/RoutesList.tsx
+++ b/app/components/sheets/RoutesList.tsx
@@ -4,8 +4,8 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import SegmentedControl, { NativeSegmentedControlIOSChangeEvent } from "@react-native-segmented-control/segmented-control";
 import { BottomSheetModal, BottomSheetView, BottomSheetFlatList } from "@gorhom/bottom-sheet";
 import { MaterialCommunityIcons, FontAwesome } from '@expo/vector-icons';
-import { MapDirectionList, MapRoute } from "aggie-spirit-api";
 
+import { IDirectionList, IMapRoute } from "../../../utils/interfaces";
 import useAppStore from "../../stores/useAppStore";
 import BusIcon from "../ui/BusIcon";
 import SheetHeader from "../ui/SheetHeader";
@@ -31,7 +31,7 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
     const [selectedRouteCategory, setSelectedRouteCategory] = useState<"favorites" | "all">("all");
     const [alertIcon, setAlertIcon] = useState<"bell-outline" | "bell-badge">("bell-outline");
 
-    const handleRouteSelected = (selectedRoute: MapRoute) => {        
+    const handleRouteSelected = (selectedRoute: IMapRoute) => {        
         setSelectedRoute(selectedRoute);
         setDrawnRoutes([selectedRoute]);
         presentSheet("routeDetails");
@@ -131,7 +131,7 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
             <BottomSheetFlatList
                 contentContainerStyle={{ paddingBottom: 35 }}
                 data={drawnRoutes}
-                keyExtractor={(route: MapRoute) => route.key}
+                keyExtractor={(route: IMapRoute) => route.key}
                 style={{ marginLeft: 16 }}
                 renderItem={({item: route}) => {
                     return (
@@ -145,7 +145,7 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
                                     }
                                 </View>
                                 <View style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-                                    {route.directionList.map((elm: MapDirectionList, index: number) => (
+                                    {route.directionList.map((elm: IDirectionList, index: number) => (
                                         <React.Fragment key={index}>
                                             <Text>{elm.destination}</Text>
                                             {index !== route.directionList.length - 1 && <Text style={{ marginHorizontal: 2 }}>|</Text>}

--- a/app/components/sheets/StopTimetable.tsx
+++ b/app/components/sheets/StopTimetable.tsx
@@ -1,0 +1,162 @@
+import { ActivityIndicator, Button, Text, TouchableOpacity, View } from "react-native";
+import { BottomSheetModal, BottomSheetView, BottomSheetFlatList, BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import BusIcon from "../ui/BusIcon";
+import { useDebugValue, useEffect, useState } from "react";
+import { MapStop, RouteStopSchedule, StopSchedulesResponse, getStopSchedules } from "aggie-spirit-api";
+import useAppStore from "../../stores/useAppStore";
+import { Ionicons } from "@expo/vector-icons";
+import TimeBubble from "../ui/TimeBubble";
+import Timetable from "../ui/Timetable";
+import { FlatList } from "react-native-gesture-handler";
+import { get } from "react-native/Libraries/TurboModule/TurboModuleRegistry";
+
+
+interface SheetProps {
+    sheetRef: React.RefObject<BottomSheetModal>
+}
+
+// TODO: Fill in route details with new UI
+const StopTimetable: React.FC<SheetProps> = ({ sheetRef }) => {
+    const currentSelectedStop = useAppStore((state) => state.selectedStop);
+    const setCurrentSelectedStop = useAppStore((state) => state.setSelectedStop);
+    const selectedRoute = useAppStore((state) => state.selectedRoute);
+    const authToken = useAppStore((state) => state.authToken);
+    const routes = useAppStore((state) => state.routes);
+
+    const [ selectedStop, setSelectedStop ] = useState<MapStop | null>(null);
+    const [ showNonRouteSchedules, setShowNonRouteSchedules ] = useState<boolean>(false);
+    const [ nonRouteSchedules, setNonRouteSchedules ] = useState<RouteStopSchedule[] | null>(null);
+    const [ routeSchedules, setRouteSchedules ] = useState<RouteStopSchedule[] | null>(null);
+
+    function loadSchedule(newSelectedStop: MapStop | null = null) {
+        if (!newSelectedStop) return;
+
+        getStopSchedules(newSelectedStop?.stopCode, new Date(), authToken!)
+            .then((response) => {
+                // find the schedules for the selected route
+                var routeStops = response.routeStopSchedules.filter((schedule) => schedule.routeName === selectedRoute?.name)
+
+                // filter anything that is end of route
+                routeStops = routeStops.filter((schedule) => !schedule.isEndOfRoute);
+                setRouteSchedules(routeStops);
+
+                // filter out non route schedules
+                var nonRouteStops = response.routeStopSchedules.filter((schedule) => schedule.routeName !== selectedRoute?.name)
+
+                // filter anything that doesnt have stop times
+                nonRouteStops = nonRouteStops.filter((schedule) => schedule.stopTimes.length > 0);
+                setNonRouteSchedules(nonRouteStops)  
+            })
+            .catch((error) => {
+                console.error(error);
+            })
+    }
+
+    function getLineColor(shortName: string) {
+        const route = routes.find((route) => route.shortName === shortName);
+        return route?.directionList[0]?.lineColor ?? "#500000";
+    }
+
+
+    // prevent data from disappearing when the sheet is closed
+    useEffect(() => {
+        if (!currentSelectedStop) return;
+
+        setSelectedStop(currentSelectedStop);
+        loadSchedule(currentSelectedStop);
+    }, [currentSelectedStop])
+
+
+    const snapPoints = ['25%', '45%', '85%'];
+
+    function closeModal() {
+        sheetRef.current?.dismiss();
+        setRouteSchedules(null);
+        setNonRouteSchedules(null);
+        setCurrentSelectedStop(null);
+        setShowNonRouteSchedules(false);
+    }
+
+    return (
+        <BottomSheetModal
+            ref={sheetRef}
+            snapPoints={snapPoints}
+            index={1}
+            enablePanDownToClose={false}
+        >
+            <BottomSheetView>
+                <View style={{ flexDirection: "row", alignItems: 'center', marginBottom: 8, marginHorizontal: 16 }}>
+                    <Text style={{ fontWeight: 'bold', fontSize: 28, flex: 1 }}>{selectedStop?.name ?? "Something went wrong"}</Text>
+
+                    <TouchableOpacity style={{ alignContent: 'center', justifyContent: 'flex-end' }} onPress={closeModal}>
+                        <Ionicons name="close-circle" size={32} color="grey" />
+                    </TouchableOpacity>
+                </View>
+                <View style={{ height: 1, backgroundColor: "#eaeaea", marginTop: 8 }} />
+
+                { !routeSchedules && <ActivityIndicator style={{ marginTop: 16 }} /> }
+            </BottomSheetView>
+            <BottomSheetScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 35, paddingTop: 4 }}>
+                { routeSchedules &&
+                    <FlatList
+                        data={routeSchedules}
+                        scrollEnabled={false}
+                        keyExtractor={(item, index) => index.toString()}
+                        ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: "#eaeaea", marginVertical: 8 }} />}
+                        renderItem={({ item, index }) => {
+                            return (
+                                <View>
+                                    <Timetable item={item} tintColor={getLineColor(item.routeNumber)} />
+                                </View>
+                            )
+                        }}
+                    />
+                }
+
+                
+
+                { showNonRouteSchedules &&
+                    <View>
+                        <View style={{ height: 1, backgroundColor: "#eaeaea", marginVertical: 8 }} />
+                        <FlatList
+                            data={nonRouteSchedules}
+                            keyExtractor={(item, index) => index.toString()}
+                            scrollEnabled={false}
+                            ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: "#eaeaea", marginVertical: 8 }} />}
+                            renderItem={({ item }) => {
+                                return (
+                                    <Timetable item={item} tintColor={getLineColor(item.routeNumber)} />
+                                )
+                            }}
+                        />
+                    </View>
+                }
+
+                { nonRouteSchedules && nonRouteSchedules.length > 0 && 
+                    // show other routes button
+                    <TouchableOpacity 
+                        style={{
+                            padding: 8,
+                            paddingHorizontal: 16,
+                            marginHorizontal: 16,
+                            borderRadius: 8,
+                            marginTop: 16,
+                            alignSelf: 'center',
+                            backgroundColor: getLineColor(selectedRoute?.shortName ?? "#550000"),
+                        }}
+                        onPress={() => setShowNonRouteSchedules(!showNonRouteSchedules)}
+                    >
+                        <Text style={{color: "white"}}>{showNonRouteSchedules ? "Hide": "Show"} Other Routes</Text>
+                    </TouchableOpacity>
+                }
+
+            </BottomSheetScrollView>
+            
+
+            
+        </BottomSheetModal>
+    )
+}
+
+
+export default StopTimetable;

--- a/app/components/ui/StopCell.tsx
+++ b/app/components/ui/StopCell.tsx
@@ -53,8 +53,6 @@ const StopCell: React.FC<Props> = ({ stop, directionTimes, color, disabled }) =>
         presentSheet("stopTimetable")
     }
 
-
-
     return (
         <TouchableOpacity style={{ marginTop: 8 }} onPress={onPress} disabled={disabled}>
             <Text style={{ fontSize: 22, fontWeight: "bold", marginRight: 32 }}>{stop.name}</Text>

--- a/app/components/ui/StopCell.tsx
+++ b/app/components/ui/StopCell.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { View, Text, ActivityIndicator, FlatList, TouchableOpacity } from 'react-native';
-import { MapStop, RouteDirectionTime } from "aggie-spirit-api";
 
+import { IRouteDirectionTime, IStop } from "../../../utils/interfaces";
 import TimeBubble from "./TimeBubble";
 import useAppStore from "../../stores/useAppStore";
 
 interface Props {
-    stop: MapStop
-    directionTimes: RouteDirectionTime
+    stop: IStop
+    directionTimes: IRouteDirectionTime
     color: string
     disabled: boolean
 }

--- a/app/components/ui/StopCell.tsx
+++ b/app/components/ui/StopCell.tsx
@@ -1,17 +1,21 @@
 import React, { useState, useEffect } from "react";
-import { View, Text, ActivityIndicator, FlatList } from 'react-native';
+import { View, Text, ActivityIndicator, FlatList, TouchableOpacity } from 'react-native';
 import { MapStop, RouteDirectionTime } from "aggie-spirit-api";
 
 import TimeBubble from "./TimeBubble";
+import useAppStore from "../../stores/useAppStore";
 
 interface Props {
     stop: MapStop
     directionTimes: RouteDirectionTime
     color: string
+    disabled: boolean
 }
 
-const RouteEstimates: React.FC<Props> = ({ stop, directionTimes, color }) => {
+const StopCell: React.FC<Props> = ({ stop, directionTimes, color, disabled }) => {
     const [status, setStatus] = useState('On Time');
+    const presentSheet = useAppStore((state) => state.presentSheet);
+    const setSelectedStop = useAppStore((state) => state.setSelectedStop);
 
     useEffect(() => {
         let totalDeviation = 0;
@@ -43,24 +47,32 @@ const RouteEstimates: React.FC<Props> = ({ stop, directionTimes, color }) => {
         }
     }, [directionTimes]);
 
+    // when cell is tapped, open the stop timetable
+    function onPress() {
+        setSelectedStop(stop);
+        presentSheet("stopTimetable")
+    }
+
+
+
     return (
-        <View style={{ marginTop: 4 }}>
+        <TouchableOpacity style={{ marginTop: 8 }} onPress={onPress} disabled={disabled}>
             <Text style={{ fontSize: 22, fontWeight: "bold", marginRight: 32 }}>{stop.name}</Text>
 
             {status == "Loading" ?
-                <View style={{ flexDirection: "row", alignItems: "center", marginTop: 2 }}>
+                <View style={{ flexDirection: "row", alignItems: "center", marginVertical: 2 }}>
                     <ActivityIndicator style={{ justifyContent: "flex-start" }} />
                     <View style={{ flex: 1 }} />
                 </View>
                 :
-                <Text style={{ marginBottom: 8 }}>{status}</Text>
+                <Text style={{ marginBottom: 8, marginTop: 2 }}>{status}</Text>
             }
 
             <FlatList
                 horizontal
                 scrollEnabled={false}
                 data={directionTimes.nextDeparts}
-                keyExtractor={(_, index) => String(index)}
+                keyExtractor={(_, index) => index.toString()}
                 renderItem={({ item: departureTime, index }) => {
                     let date;
                     let live = false;
@@ -82,11 +94,8 @@ const RouteEstimates: React.FC<Props> = ({ stop, directionTimes, color }) => {
                     )
                 }}
             />
-
-            {/* Line seperator */}
-            <View style={{ height: 1, backgroundColor: "#eaeaea", marginTop: 8 }} />
-        </View>
+        </TouchableOpacity>
     )
 }
 
-export default RouteEstimates;
+export default StopCell;

--- a/app/components/ui/Timetable.tsx
+++ b/app/components/ui/Timetable.tsx
@@ -9,10 +9,10 @@ interface Props {
     tintColor: string
 }
 
-const Timetable: React.FC<Props> = ({item, tintColor}) => {
+const Timetable: React.FC<Props> = ({ item, tintColor }) => {
 
     return (
-        <View style={{marginLeft: 16, paddingTop: 8 }}>
+        <View style={{ marginLeft: 16, paddingTop: 8 }}>
             <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 8 }}>
                 <BusIcon name={item.routeNumber} color={tintColor} style={{ marginRight: 8 }} />
                 <View>
@@ -20,7 +20,7 @@ const Timetable: React.FC<Props> = ({item, tintColor}) => {
                     <Text>{item.directionName}</Text>
                 </View>
             </View>
-            
+
             <View style={{
                 flexDirection: "row",
                 alignItems: "center",
@@ -30,18 +30,18 @@ const Timetable: React.FC<Props> = ({item, tintColor}) => {
                 flexWrap: "wrap"
             }}>
 
-                { item.stopTimes.length > 0 && item.stopTimes.map((time) => {
+                {item.stopTimes.length > 0 && item.stopTimes.map((time) => {
 
                     const dt = new Date(time.scheduledDepartTimeUtc)
-                    var ds = dt.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true, timeZone: 'America/Chicago' })
+                    let ds = dt.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true, timeZone: 'America/Chicago' })
 
                     // cut off the AM/PM
                     ds = ds.substring(0, ds.length - 3);
 
-                    var color;
+                    let color;
                     if (dt < new Date()) {
                         color = "grey";
-                    } 
+                    }
                     else if (time.isRealtime) {
                         color = "green";
                     }
@@ -49,13 +49,13 @@ const Timetable: React.FC<Props> = ({item, tintColor}) => {
                         color = "black";
                     }
                     return (
-                        <View style={{marginBottom: 8, flexBasis: "20%"}} key={time.scheduledDepartTimeUtc}>
+                        <View style={{ marginBottom: 8, flexBasis: "20%" }} key={time.scheduledDepartTimeUtc}>
                             <TimeBubble key={time.scheduledDepartTimeUtc} time={ds} color={color} live={time.isRealtime} />
                         </View>
                     )
                 })}
 
-                { item.stopTimes.length == 0 && !item.isEndOfRoute && <Text style={{ color: "grey" }}>Bus is not scheduled today.</Text> }
+                {item.stopTimes.length == 0 && !item.isEndOfRoute && <Text style={{ color: "grey" }}>Bus is not scheduled today.</Text>}
             </View>
         </View>
     );

--- a/app/components/ui/Timetable.tsx
+++ b/app/components/ui/Timetable.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import BusIcon from './BusIcon';
+import TimeBubble from './TimeBubble';
+import { RouteStopSchedule } from 'aggie-spirit-api';
+
+interface Props {
+    item: RouteStopSchedule
+    tintColor: string
+}
+
+const Timetable: React.FC<Props> = ({item, tintColor}) => {
+
+    return (
+        <View style={{marginLeft: 16, paddingTop: 8 }}>
+            <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 8 }}>
+                <BusIcon name={item.routeNumber} color={tintColor} style={{ marginRight: 8 }} />
+                <View>
+                    <Text style={{ fontWeight: "bold", fontSize: 24, flex: 1 }}>{item.routeName}</Text>
+                    <Text>{item.directionName}</Text>
+                </View>
+            </View>
+            
+            <View style={{
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+                marginBottom: 8,
+                marginRight: 16,
+                flexWrap: "wrap"
+            }}>
+
+                { item.stopTimes.length > 0 && item.stopTimes.map((time) => {
+
+                    const dt = new Date(time.scheduledDepartTimeUtc)
+                    var ds = dt.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true, timeZone: 'America/Chicago' })
+
+                    // cut off the AM/PM
+                    ds = ds.substring(0, ds.length - 3);
+
+                    var color;
+                    if (dt < new Date()) {
+                        color = "grey";
+                    } 
+                    else if (time.isRealtime) {
+                        color = "green";
+                    }
+                    else {
+                        color = "black";
+                    }
+                    return (
+                        <View style={{marginBottom: 8, flexBasis: "20%"}} key={time.scheduledDepartTimeUtc}>
+                            <TimeBubble key={time.scheduledDepartTimeUtc} time={ds} color={color} live={time.isRealtime} />
+                        </View>
+                    )
+                })}
+
+                { item.stopTimes.length == 0 && !item.isEndOfRoute && <Text style={{ color: "grey" }}>Bus is not scheduled today.</Text> }
+            </View>
+        </View>
+    );
+};
+
+export default Timetable;

--- a/app/components/ui/Timetable.tsx
+++ b/app/components/ui/Timetable.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Text, View } from 'react-native';
+
+import { IRouteStopSchedule } from '../../../utils/interfaces';
 import BusIcon from './BusIcon';
 import TimeBubble from './TimeBubble';
-import { RouteStopSchedule } from 'aggie-spirit-api';
 
 interface Props {
-    item: RouteStopSchedule
+    item: IRouteStopSchedule
     tintColor: string
 }
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,16 +1,14 @@
 import { useEffect, useRef } from 'react';
 import { View, Alert } from 'react-native';
-import { BaseDataResponse, MapRoute, PatternPathsResponse, getAuthentication, getBaseData, getPatternPaths } from "aggie-spirit-api";
+import { getAuthentication, getBaseData, getPatternPaths } from "aggie-spirit-api";
 import { BottomSheetModal, BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import useAppStore from './stores/useAppStore';
-import { GetBaseDataResponseSchema, GetPatternPathsResponseSchema } from "../utils/updatedInterfaces";
+import { GetBaseDataResponseSchema, GetPatternPathsResponseSchema, IGetBaseDataResponse, IGetPatternPathsResponse, IMapRoute } from "../utils/interfaces";
 import MapView from './components/MapView';
 import RoutesList from './components/sheets/RoutesList';
 import AlertList from './components/sheets/AlertList';
 import RouteDetails from './components/sheets/RouteDetails';
 import StopTimetable from './components/sheets/StopTimetable';
-
-
 
 const Home = () => {
     const setAuthToken = useAppStore((state) => state.setAuthToken);
@@ -54,7 +52,7 @@ const Home = () => {
             }
 
             // Add each pattern path to the corresponding route
-            function addPatternPathsToRoutes(baseDataRoutes: MapRoute[], patternPathsResponse: PatternPathsResponse[]) {
+            function addPatternPathsToRoutes(baseDataRoutes: IMapRoute[], patternPathsResponse: IGetPatternPathsResponse) {
                 for (let elm of patternPathsResponse) {
                     const foundObject = baseDataRoutes.find(route => route.key === elm.routeKey);
                     if (foundObject) {
@@ -70,7 +68,7 @@ const Home = () => {
                         return;
                     }
 
-                    const baseData: BaseDataResponse = await fetchBaseData(authToken);
+                    const baseData: IGetBaseDataResponse = await fetchBaseData(authToken);
                     const patternPathsResponse = await fetchPatternPaths(baseData.routes.map(route => route.key), authToken);
 
                     // Add patternPaths to routes

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,6 +8,7 @@ import MapView from './components/MapView';
 import RoutesList from './components/sheets/RoutesList';
 import AlertList from './components/sheets/AlertList';
 import RouteDetails from './components/sheets/RouteDetails';
+import StopTimetable from './components/sheets/StopTimetable';
 
 
 
@@ -99,6 +100,7 @@ const Home = () => {
     const routesListSheetRef = useRef<BottomSheetModal>(null);
     const alertListSheetRef = useRef<BottomSheetModal>(null);
     const routeDetailSheetRef = useRef<BottomSheetModal>(null);
+    const stopTimetableSheetRef = useRef<BottomSheetModal>(null);
 
     setPresentSheet((sheet) => {
         switch (sheet) {
@@ -107,6 +109,9 @@ const Home = () => {
                 break;
             case "routeDetails":
                 routeDetailSheetRef.current?.present();
+                break;
+            case "stopTimetable":
+                stopTimetableSheetRef.current?.present();
                 break;
             default:
                 break;
@@ -126,6 +131,7 @@ const Home = () => {
                 <RouteDetails sheetRef={routeDetailSheetRef} />
                 <RoutesList sheetRef={routesListSheetRef} />
                 <AlertList sheetRef={alertListSheetRef} />
+                <StopTimetable sheetRef={stopTimetableSheetRef} />
             </View>
         </BottomSheetModalProvider>
     )

--- a/app/stores/useAppStore.ts
+++ b/app/stores/useAppStore.ts
@@ -38,6 +38,10 @@ interface AppState {
     
     presentSheet: (sheet: "routeDetails" | "alerts" | "stopTimetable") => void
     setPresentSheet: (presentSheet: (sheet: "routeDetails" | "alerts" | "stopTimetable") => void) => void
+
+    busLocationRefreshInterval: NodeJS.Timeout | null,
+    setBusRefreshInterval: (busLocationRefreshInterval: NodeJS.Timeout) => void
+    clearBusRefreshInterval: () => void
 }
 
 const useAppStore = create<AppState>()((set) => ({
@@ -89,7 +93,18 @@ const useAppStore = create<AppState>()((set) => ({
     setDrawnBuses: (buses) => set(() => ({ drawnBuses: buses })),
 
     presentSheet: (sheet) => {console.log(sheet)},
-    setPresentSheet: (presentSheet) => set(() => ({ presentSheet }))
+    setPresentSheet: (presentSheet) => set(() => ({ presentSheet })),
+
+    // Timeouts
+    busLocationRefreshInterval: null,
+    setBusRefreshInterval: (busLocationRefreshInterval) => set(() => ({ busLocationRefreshInterval })),
+    clearBusRefreshInterval: () => set(state => {
+        if (state.busLocationRefreshInterval) {
+            clearInterval(state.busLocationRefreshInterval);
+        }
+
+        return { busLocationRefreshInterval: null };
+    })
 }));
 
 export default useAppStore;

--- a/app/stores/useAppStore.ts
+++ b/app/stores/useAppStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { MapRoute, MapServiceInterruption, NextDepartureTimesResponse, Vehicle } from "aggie-spirit-api";
+import { MapRoute, MapServiceInterruption, MapStop, NextDepartureTimesResponse, Vehicle } from "aggie-spirit-api";
 import { CachedStopEstimate as CachedStopDepartureTimes } from "types/app";
 
 interface AppState {
@@ -24,14 +24,20 @@ interface AppState {
     setSelectedRoute: (selectedRoute: MapRoute) => void,
     clearSelectedRoute: () => void,
 
+    selectedStop: MapStop | null,
+    setSelectedStop: (selectedStop: MapStop | null) => void,
+
+    selectedDirection: string | null,
+    setSelectedDirection: (selectedDirection: string | null) => void,
+
     drawnBuses: Vehicle[],
     setDrawnBuses: (buses: Vehicle[]) => void,
      
     isGameday: boolean
     setIsGameday: (isGameday: boolean) => void
 
-    presentSheet: (sheet: "routeDetails" | "alerts") => void
-    setPresentSheet: (presentSheet: (sheet: "routeDetails" | "alerts") => void) => void
+    presentSheet: (sheet: "routeDetails" | "alerts" | "stopTimetable") => void
+    setPresentSheet: (presentSheet: (sheet: "routeDetails" | "alerts" | "stopTimetable") => void) => void
 }
 
 const useAppStore = create<AppState>()((set) => ({
@@ -69,6 +75,12 @@ const useAppStore = create<AppState>()((set) => ({
 
         return { selectedRoute: null };
     }),
+
+    selectedStop: null,
+    setSelectedStop: (selectedStop) => set(() => ({ selectedStop })),
+
+    selectedDirection: null,
+    setSelectedDirection: (selectedDirection) => set(() => ({ selectedDirection })),
 
     drawnBuses: [],
     setDrawnBuses: (buses) => set(() => ({ drawnBuses: buses })),

--- a/app/stores/useAppStore.ts
+++ b/app/stores/useAppStore.ts
@@ -35,10 +35,7 @@ interface AppState {
 
     drawnBuses: Vehicle[],
     setDrawnBuses: (buses: Vehicle[]) => void,
-     
-    isGameday: boolean
-    setIsGameday: (isGameday: boolean) => void
-
+    
     presentSheet: (sheet: "routeDetails" | "alerts" | "stopTimetable") => void
     setPresentSheet: (presentSheet: (sheet: "routeDetails" | "alerts" | "stopTimetable") => void) => void
 }
@@ -90,9 +87,6 @@ const useAppStore = create<AppState>()((set) => ({
 
     drawnBuses: [],
     setDrawnBuses: (buses) => set(() => ({ drawnBuses: buses })),
-
-    isGameday: false,
-    setIsGameday: (isGameday) => set(() => ({ isGameday })),
 
     presentSheet: (sheet) => {console.log(sheet)},
     setPresentSheet: (presentSheet) => set(() => ({ presentSheet }))

--- a/app/stores/useAppStore.ts
+++ b/app/stores/useAppStore.ts
@@ -16,6 +16,9 @@ interface AppState {
     setDrawnRoutes: (routes: MapRoute[]) => void
     resetDrawnRoutes: () => void,
 
+    favoriteRoutes: MapRoute[],
+    setFavoriteRoutes: (favoriteRoutes: MapRoute[]) => void,
+
     stopEstimates: CachedStopDepartureTimes[],
     updateStopEstimate: (stopEstimate: NextDepartureTimesResponse, stopCode: string) => void,
     clearStopEstimates: () => void,
@@ -47,6 +50,9 @@ const useAppStore = create<AppState>()((set) => ({
     drawnRoutes: [],
     setDrawnRoutes: (routes) => set(() => ({ drawnRoutes: routes })),
     resetDrawnRoutes: () => set(state => ({ drawnRoutes: state.routes })),
+
+    favoriteRoutes: [],
+    setFavoriteRoutes: (favoriteRoutes) => set(() => ({ favoriteRoutes })),
 
     stopEstimates: [],
     updateStopEstimate: (departureTimes, stopCode) => set(state => {

--- a/utils/interfaces.ts
+++ b/utils/interfaces.ts
@@ -1,5 +1,4 @@
 // TODO: Fix all of the 'any' types once the API has live data
-
 import { z } from "zod";
 
 // From Map API
@@ -162,6 +161,32 @@ export const TimetableRouteSchema = z.object({
 });
 export type ITimetableRoute = z.infer<typeof TimetableRouteSchema>
 
+export const StopTimeSchema = z.object({
+    scheduledDepartTimeUtc: z.string(),
+    estimatedDepartTimeUtc: z.string(),
+    isRealtime: z.boolean(),
+    tripPointId: z.string(),
+    isLastPoint: z.boolean().nullable(),
+    isCancelled: z.boolean(),
+    isOffRoute: z.boolean()
+});
+export type IStopTime = z.infer<typeof StopTimeSchema>
+
+export const RouteStopScheduleSchema = z.object({
+    routeName: z.string(),
+    routeNumber: z.string(),
+    directionName: z.string(),
+    stopTimes: z.array(z.any()),
+    frequencyInfo: z.any(),
+    hasTrips: z.boolean(),
+    hasSchedule: z.boolean(),
+    isEndOfRoute: z.boolean(),
+    isTemporaryStopOnly: z.boolean(),
+    isClosedRegularStop: z.boolean(),
+    serviceInterruptions: z.array(z.any())
+});
+export type IRouteStopSchedule = z.infer<typeof RouteStopScheduleSchema>
+
 // /RouteMap/GetBaseData
 export const GetBaseDataResponseSchema = z.object({
     routes: z.array(MapRouteSchema),
@@ -188,7 +213,6 @@ export type IGetNextDepartTimesResponse = z.infer<typeof GetNextDepartTimesRespo
 // /RouteMap/GetVehicles
 export const GetVehiclesResponseSchema = z.array(z.object({
     routeKey: z.string(),
-    patternPaths: z.array(PatternPathSchema),
     vehiclesByDirections: z.array(VehicleByDirection).nullable()
 }).nullable());
 export type IGetVehiclesResponse = z.infer<typeof GetVehiclesResponseSchema>
@@ -213,3 +237,18 @@ export type IGetNearbyRoutesResponse = z.infer<typeof GetNearbyRoutesResponseSch
 // /Home/GetNextStopTimes
 export const GetNextStopTimesResponseSchema = z.array(TimetableRouteSchema);
 export type IGetNextStopTimesResponse = z.infer<typeof GetNextStopTimesResponseSchema>
+
+// /Schedule/GetStopSchedules
+export const GetStopSchedulesResponseSchema = z.object({
+    routeStopSchedules: z.array(RouteStopScheduleSchema),
+    date: z.string(),
+    amenities: z.array(AmenitySchema)
+});
+export type IGetStopSchedulesResponse = z.infer<typeof GetStopSchedulesResponseSchema>
+
+export const GetStopEstimatesResponseSchema = z.object({
+    routeStopSchedules: z.array(z.any()),
+    date: z.string(),
+    amenities: z.array(AmenitySchema)
+});
+export type IGetStopEstimatesResponse = z.infer<typeof GetStopEstimatesResponseSchema>

--- a/utils/updatedInterfaces.ts
+++ b/utils/updatedInterfaces.ts
@@ -7,11 +7,13 @@ export const PatternListSchema = z.object({
     key: z.string(),
     isDisplay: z.boolean()
 });
+export type IPatternList = z.infer<typeof PatternListSchema>
 
 export const DirectionSchema = z.object({
     key: z.string(),
     name: z.string()
 });
+export type IDirection = z.infer<typeof DirectionSchema>
 
 export const DirectionListSchema = z.object({
     direction: DirectionSchema,
@@ -21,12 +23,14 @@ export const DirectionListSchema = z.object({
     patternList: z.array(PatternListSchema),
     serviceInterruptionKeys: z.array(z.number())
 });
+export type IDirectionList = z.infer<typeof DirectionListSchema>
 
 export const StopSchema = z.object({
     name: z.string(),
     stopCode: z.string(),
     stopType: z.number()
 });
+export type IStop = z.infer<typeof StopSchema>
 
 export const PatternPointSchema = z.object({
     key: z.string(),
@@ -34,6 +38,7 @@ export const PatternPointSchema = z.object({
     longitude: z.number(),
     stop: StopSchema.nullable()
 });
+export type IPatternPoint = z.infer<typeof PatternPointSchema>
 
 export const PatternPathSchema = z.object({
     patternKey: z.string(),
@@ -41,6 +46,7 @@ export const PatternPathSchema = z.object({
     patternPoints: z.array(PatternPointSchema),
     segmentPaths: z.array(z.any())
 });
+export type IPatternPath = z.infer<typeof PatternPathSchema>
 
 // Appending 'Map' to front of name since timtable has a different RouteSchema
 export const MapRouteSchema = z.object({
@@ -50,6 +56,7 @@ export const MapRouteSchema = z.object({
     directionList: z.array(DirectionListSchema),
     patternPaths: z.array(PatternPathSchema),
 });
+export type IMapRoute = z.infer<typeof MapRouteSchema>
 
 // Appending 'Map' to front of name since timtable has a different ServiceInterruptionSchema
 export const MapServiceInterruptionSchema = z.object({
@@ -62,12 +69,14 @@ export const MapServiceInterruptionSchema = z.object({
     dailyStartTime: z.string(),
     dailyEndTime: z.string()
 });
+export type IMapServiceInterruption = z.infer<typeof MapServiceInterruptionSchema>
 
 export const DepartTimeSchema = z.object({
     estimatedDepartTimeUtc: z.string().nullable(),
     scheduledDepartTimeUtc: z.string().nullable(),
     isOffRoute: z.boolean()
 });
+export type IDepartTime = z.infer<typeof DepartTimeSchema>
 
 export const RouteDirectionTimeSchema = z.object({
     routeKey: z.string(),
@@ -75,6 +84,7 @@ export const RouteDirectionTimeSchema = z.object({
     nextDeparts: z.array(DepartTimeSchema),
     frequencyInfo: z.any().nullable()
 });
+export type IRouteDirectionTime = z.infer<typeof RouteDirectionTimeSchema>
 
 export const BusLocationSchema = z.object({
     lastGpsDate: z.string(),
@@ -83,11 +93,13 @@ export const BusLocationSchema = z.object({
     speed: z.number(),
     heading: z.number()
 });
+export type IBusLocation = z.infer<typeof BusLocationSchema>
 
 export const AmenitySchema = z.object({
     name: z.string(),
     iconName: z.string(),
 });
+export type IAmenity = z.infer<typeof AmenitySchema>
 
 export const VehicleSchema = z.object({
     key: z.string(),
@@ -101,11 +113,13 @@ export const VehicleSchema = z.object({
     amenities: z.array(AmenitySchema),
     isExtraTrip: z.boolean()
 });
+export type IVehicle = z.infer<typeof VehicleSchema>
 
 export const VehicleByDirection = z.object({
     directionKey: z.string(),
     vehicles: z.array(VehicleSchema)
 });
+export type IVehicleByDirection = z.infer<typeof VehicleByDirection>
 
 // From Bus Times API
 export const TimetableServiceInterruptionSchema = z.object({
@@ -114,6 +128,15 @@ export const TimetableServiceInterruptionSchema = z.object({
     serviceInterruptionTimeRange: z.string(),
     isStopClosed: z.boolean()
 });
+export type ITimetableServiceInterruption = z.infer<typeof TimetableServiceInterruptionSchema>
+
+export const NextStopTimeSchema = z.object({
+    scheduledDepartTimeUtc: z.string().nullable(),
+    estimatedDepartTimeUtc: z.string().nullable(),
+    isRealtime: z.boolean(),
+    isOffRoute: z.boolean()
+});
+export type INextStopTime = z.infer<typeof NextStopTimeSchema>
 
 export const NearbyStopsSchema = z.object({
     directionKey: z.string(),
@@ -122,16 +145,12 @@ export const NearbyStopsSchema = z.object({
     stopCode: z.string(),
     stopName: z.string().nullable(),
     isTemporary: z.boolean(),
-    nextStopTimes: z.array(z.object({
-        scheduledDepartTimeUtc: z.string().nullable(),
-        estimatedDepartTimeUtc: z.string().nullable(),
-        isRealtime: z.boolean(),
-        isOffRoute: z.boolean()
-    })),
+    nextStopTimes: z.array(NextStopTimeSchema),
     frequencyInfo: z.any().nullable(),
     serviceInterruptions: z.array(TimetableServiceInterruptionSchema),
     amenities: z.array(AmenitySchema)
 });
+export type INearbyStops = z.infer<typeof NearbyStopsSchema>
 
 export const TimetableRouteSchema = z.object({
     routeKey: z.string(),
@@ -141,12 +160,14 @@ export const TimetableRouteSchema = z.object({
     distance: z.number().nullable(),
     nearbyStops: z.array(NearbyStopsSchema)
 });
+export type ITimetableRoute = z.infer<typeof TimetableRouteSchema>
 
 // /RouteMap/GetBaseData
 export const GetBaseDataResponseSchema = z.object({
     routes: z.array(MapRouteSchema),
     serviceInterruptions: z.array(MapServiceInterruptionSchema)
 });
+export type IGetBaseDataResponse = z.infer<typeof GetBaseDataResponseSchema>
 
 // /RouteMap/GetPatternPaths
 export const GetPatternPathsResponseSchema = z.array(z.object({
@@ -154,13 +175,15 @@ export const GetPatternPathsResponseSchema = z.array(z.object({
     patternPaths: z.array(PatternPathSchema),
     vehiclesByDirections: z.array(VehicleByDirection).nullable()
 }));
+export type IGetPatternPathsResponse = z.infer<typeof GetPatternPathsResponseSchema>
 
 // /RouteMap/GetNextDepartTimes
 export const GetNextDepartTimesResponseSchema = z.object({
     stopCode: z.string(),
     routeDirectionTimes: z.array(RouteDirectionTimeSchema),
     amenities: z.array(AmenitySchema)
-})
+});
+export type IGetNextDepartTimesResponse = z.infer<typeof GetNextDepartTimesResponseSchema>
 
 // /RouteMap/GetVehicles
 export const GetVehiclesResponseSchema = z.array(z.object({
@@ -168,9 +191,11 @@ export const GetVehiclesResponseSchema = z.array(z.object({
     patternPaths: z.array(PatternPathSchema),
     vehiclesByDirections: z.array(VehicleByDirection).nullable()
 }).nullable());
+export type IGetVehiclesResponse = z.infer<typeof GetVehiclesResponseSchema>
 
 // /Home/GetActiveRoutes
 export const GetActiveRoutesResponseSchema = z.array(z.string());
+export type IGetActiveRoutesResponse = z.infer<typeof GetActiveRoutesResponseSchema>
 
 // /Home/GetNearbyRoutes
 export const GetNearbyRoutesResponseSchema = z.object({
@@ -183,6 +208,8 @@ export const GetNearbyRoutesResponseSchema = z.object({
     nextMaxRadius: z.number(),
     canLoadMore: z.boolean()
 });
+export type IGetNearbyRoutesResponse = z.infer<typeof GetNearbyRoutesResponseSchema>
 
 // /Home/GetNextStopTimes
 export const GetNextStopTimesResponseSchema = z.array(TimetableRouteSchema);
+export type IGetNextStopTimesResponse = z.infer<typeof GetNextStopTimesResponseSchema>


### PR DESCRIPTION
Fixed setInterval calls so they do not continue running when the component is unmounted.

I added pull to refresh for the stop routes instead of doing a 30-second interval. We have to make ~20 API calls to get all the data we need. The data does not change very often and the user can just pull to refresh if they want new data.