### PR TITLE
add "Campus Circulator" as subtitle to routes with only one direction

### DIFF
--- a/app/components/sheets/RoutesList.tsx
+++ b/app/components/sheets/RoutesList.tsx
@@ -152,7 +152,7 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
                                         <FontAwesome name="star" size={16} color="#ffcc01" style={{marginLeft: 4}} />
                                     }
                                 </View>
-                                { route.directionList.length > 1 &&
+                                { route.directionList.length > 1 ?
                                     <View style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
                                         {route.directionList.map((elm: IDirectionList, index: number) => (
                                             <React.Fragment key={index}>
@@ -161,6 +161,8 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
                                             </React.Fragment>
                                         ))}
                                     </View>
+                                    :
+                                    <Text>Campus Circulator</Text>
                                 } 
                             </View>
                         </TouchableOpacity>


### PR DESCRIPTION
<img width="396" alt="Screenshot 2024-02-05 at 9 17 11 AM" src="https://github.com/Reveille-Rides/ReveilleRides/assets/12686250/3e72d422-3ae0-4fdc-a0b3-db97698d7097">
