### PR TITLE
Select other Route from timetable

### DIFF
--- a/app/components/sheets/RouteDetails.tsx
+++ b/app/components/sheets/RouteDetails.tsx
@@ -77,10 +77,14 @@ const RouteDetails: React.FC<SheetProps> = ({ sheetRef }) => {
     // Update the selected route when the currentSelectedRoute changes but only if it is not null
     // Prevents visual glitch when the sheet is closed and the selected route is null
     useEffect(() => {
+        console.log("gogogogog")
         if (!currentSelectedRoute) return;
+
         setSelectedRoute(currentSelectedRoute);
 
+        // reset direction selector
         setSelectedRouteDirection(currentSelectedRoute.directionList[0]?.direction.key ?? null);
+        setSelectedDirectionIndex(0);
 
         loadStopEstimates();
     }, [currentSelectedRoute])

--- a/app/components/sheets/RouteDetails.tsx
+++ b/app/components/sheets/RouteDetails.tsx
@@ -77,7 +77,6 @@ const RouteDetails: React.FC<SheetProps> = ({ sheetRef }) => {
     // Update the selected route when the currentSelectedRoute changes but only if it is not null
     // Prevents visual glitch when the sheet is closed and the selected route is null
     useEffect(() => {
-        console.log("gogogogog")
         if (!currentSelectedRoute) return;
 
         setSelectedRoute(currentSelectedRoute);

--- a/app/components/sheets/RoutesList.tsx
+++ b/app/components/sheets/RoutesList.tsx
@@ -23,7 +23,6 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
     
     const selectedRouteCategory = useAppStore(state => state.selectedRouteCategory);
     const setSelectedRouteCategory = useAppStore(state => state.setSelectedRouteCategory);
-    const drawnRoutes = useAppStore((state) => state.drawnRoutes);
     const setDrawnRoutes = useAppStore((state) => state.setDrawnRoutes);
     const presentSheet = useAppStore((state) => state.presentSheet);
     const theme = useAppStore((state) => state.theme);
@@ -154,7 +153,7 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
                 />
                 <View style={{height: 1, backgroundColor: theme.divider, marginTop: 8}} />
 
-                { selectedRouteCategory === "favorites" && drawnRoutes.length === 0 && routes.length != 0 && (
+                { selectedRouteCategory === "favorites" && favoriteRoutes.length === 0 && routes.length != 0 && (
                     <View style={{ alignItems: 'center', marginTop: 16 }}>
                         <Text style={{color: theme.text}}>You have no favorited routes.</Text>
                     </View>
@@ -166,7 +165,7 @@ const RoutesList: React.FC<SheetProps> = ({ sheetRef }) => {
 
             <BottomSheetFlatList
                 contentContainerStyle={{ paddingBottom: 35 }}
-                data={drawnRoutes}
+                data={routes.filter(route => selectedRouteCategory === "all" || favoriteRoutes.includes(route))}
                 keyExtractor={(route: IMapRoute) => route.key}
                 style={{ marginLeft: 16 }}
                 renderItem={({item: route}) => {

--- a/app/components/sheets/StopTimetable.tsx
+++ b/app/components/sheets/StopTimetable.tsx
@@ -5,7 +5,7 @@ import { FlatList } from "react-native-gesture-handler";
 import { getStopSchedules } from "aggie-spirit-api";
 import { Ionicons } from "@expo/vector-icons";
 import useAppStore from "../../stores/useAppStore";
-import { GetStopSchedulesResponseSchema, IRouteStopSchedule, IStop } from "../../../utils/interfaces";
+import { GetStopSchedulesResponseSchema, IMapRoute, IRouteStopSchedule, IStop } from "../../../utils/interfaces";
 import Timetable from "../ui/Timetable";
 import moment from "moment-strftime";
 import DateSelector from '../ui/DateSelector';
@@ -24,6 +24,10 @@ const StopTimetable: React.FC<SheetProps> = ({ sheetRef }) => {
     const setSelectedStop = useAppStore((state) => state.setSelectedStop);
 
     const selectedRoute = useAppStore((state) => state.selectedRoute);
+    const setSelectedRoute = useAppStore((state) => state.setSelectedRoute);
+    const setSelectdDirection = useAppStore((state) => state.setSelectedRouteDirection);
+    const setDrawnRoutes = useAppStore((state) => state.setDrawnRoutes);
+    const presentSheet = useAppStore((state) => state.presentSheet);
 
     const selectedTimetableDate = useAppStore((state) => state.selectedTimetableDate);
     const setSelectedTimetableDate = useAppStore((state) => state.setSelectedTimetableDate);
@@ -171,7 +175,23 @@ const StopTimetable: React.FC<SheetProps> = ({ sheetRef }) => {
                                 scrollEnabled={false}
                                 ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: theme.divider, marginVertical: 8 }} />}
                                 renderItem={({ item }) => {
-                                    return <Timetable item={item} tintColor={getLineColor(item.routeNumber)} stopCode={selectedStop?.stopCode ?? ""} />;
+                                    return <Timetable 
+                                        item={item} 
+                                        dismissBack={() => {
+                                            const route = routes.find((route) => route.shortName === item.routeNumber);
+                                            
+                                            if (route) {
+                                                // setSelectdDirection(route.directionList[0]?.direction.key ?? "");
+                                                closeModal()
+
+                                                setSelectedRoute(route);
+                                                setDrawnRoutes([route]);
+                                                presentSheet("routeDetails");
+                                            }
+                                        }}
+                                        tintColor={getLineColor(item.routeNumber)} 
+                                        stopCode={selectedStop?.stopCode ?? ""} 
+                                    />;
                                 }}
                             />
                         </View>

--- a/app/components/sheets/StopTimetable.tsx
+++ b/app/components/sheets/StopTimetable.tsx
@@ -5,7 +5,7 @@ import { FlatList } from "react-native-gesture-handler";
 import { getStopSchedules } from "aggie-spirit-api";
 import { Ionicons } from "@expo/vector-icons";
 import useAppStore from "../../stores/useAppStore";
-import { GetStopSchedulesResponseSchema, IMapRoute, IRouteStopSchedule, IStop } from "../../../utils/interfaces";
+import { GetStopSchedulesResponseSchema, IRouteStopSchedule, IStop } from "../../../utils/interfaces";
 import Timetable from "../ui/Timetable";
 import moment from "moment-strftime";
 import DateSelector from '../ui/DateSelector';
@@ -25,7 +25,6 @@ const StopTimetable: React.FC<SheetProps> = ({ sheetRef }) => {
 
     const selectedRoute = useAppStore((state) => state.selectedRoute);
     const setSelectedRoute = useAppStore((state) => state.setSelectedRoute);
-    const setSelectdDirection = useAppStore((state) => state.setSelectedRouteDirection);
     const setDrawnRoutes = useAppStore((state) => state.setDrawnRoutes);
     const presentSheet = useAppStore((state) => state.presentSheet);
 
@@ -181,7 +180,6 @@ const StopTimetable: React.FC<SheetProps> = ({ sheetRef }) => {
                                             const route = routes.find((route) => route.shortName === item.routeNumber);
                                             
                                             if (route) {
-                                                // setSelectdDirection(route.directionList[0]?.direction.key ?? "");
                                                 closeModal()
 
                                                 setSelectedRoute(route);

--- a/app/components/ui/AlertPill.tsx
+++ b/app/components/ui/AlertPill.tsx
@@ -48,7 +48,7 @@ const AlertPill: React.FC<Props> = ({ routeId }) => {
         } else {
             setAlertIcon("bell-outline");
         }
-    }, [alerts]);
+    }, [alerts, routeId]);
 
     return (
         <TouchableOpacity onPress={() => presentSheet("alerts")}>

--- a/app/components/ui/Timetable.tsx
+++ b/app/components/ui/Timetable.tsx
@@ -6,12 +6,14 @@ import BusIcon from './BusIcon';
 import { RouteStopSchedule, getStopEstimates } from 'aggie-spirit-api';
 import useAppStore from '../../stores/useAppStore';
 import moment from 'moment';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
 
 interface Props {
     item: IRouteStopSchedule
     tintColor: string
     stopCode: string
+    dismissBack?: () => void
 }
 
 interface TableItem {
@@ -24,10 +26,10 @@ interface TableItem {
 
 interface TableItemRow {
     items: TableItem[],
-    shouldHighlight: boolean
+    shouldHighlight: boolean,
 }
 
-const Timetable: React.FC<Props> = ({ item, tintColor, stopCode }) => {
+const Timetable: React.FC<Props> = ({ item, tintColor, stopCode, dismissBack }) => {
 
     const authToken = useAppStore((state) => state.authToken);
     const selectedTimetableDate = useAppStore((state) => state.selectedTimetableDate);
@@ -146,7 +148,7 @@ const Timetable: React.FC<Props> = ({ item, tintColor, stopCode }) => {
 
     return (
         <View style={{ marginLeft: 16, paddingTop: 8 }}>
-            <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 8 }}>
+            <TouchableOpacity onPress={dismissBack} disabled={dismissBack == null} style={{ flexDirection: "row", alignItems: "center", marginBottom: 8 }}>
                 <BusIcon name={item.routeNumber} color={tintColor} style={{ marginRight: 8 }} />
                 <View>
                     <View style={{ flexDirection: "row", alignItems: "center", flex: 1}}>
@@ -155,7 +157,7 @@ const Timetable: React.FC<Props> = ({ item, tintColor, stopCode }) => {
                     </View>
                     <Text style={{color: theme.subtitle}}>{item.directionName}</Text>
                 </View>
-            </View>
+            </TouchableOpacity>
 
             <View style={{
                 marginBottom: 8,


### PR DESCRIPTION
## Describe your changes
Allow the user to tap on the title of the other route when in timetable view. Will close the timetable modal and return to route details with the new route selected.

## Issue number and link
#120 

## Dependency Changes
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have verified that any UI changes I have made work in dark mode
- [x] All of my GitHub checks have passed
- [x] I have added any new packages/updates above
- [x] I have verified that I am not submitting other changes/features outside the scope of my PR